### PR TITLE
feat: add pytests and update CI/CD to test before building

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -7,8 +7,31 @@ on:
   workflow_dispatch:
 
 jobs:
+  test:
+    runs-on: ubuntu-latest
+    env:
+      DATABASE_URL: postgresql://user:pass@localhost:5432/hackradar_test
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v4
+
+      - name: Install dependencies
+        run: uv sync --dev
+
+      - name: Run tests
+        run: uv run pytest -q
+
   build:
     runs-on: ubuntu-latest
+    needs: test
     outputs:
       image_tag: ${{ steps.meta.outputs.image_tag }}
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,3 +18,8 @@ dependencies = [
     "sqlalchemy>=2.0.41",
     "uvicorn>=0.35.0",
 ]
+
+[dependency-groups]
+dev = [
+    "pytest>=8.4.2",
+]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,10 @@
+import os
+import sys
+from pathlib import Path
+
+# Needed so backend.db can be imported during test collection.
+os.environ.setdefault("DATABASE_URL", "postgresql://user:pass@localhost:5432/hackradar_test")
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tests/test_fetch_and_store.py
+++ b/tests/test_fetch_and_store.py
@@ -1,0 +1,90 @@
+import importlib
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+pytest.importorskip("sqlalchemy")
+from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy.sql.schema import MetaData
+
+
+def load_fetch_and_store(monkeypatch):
+    # fetch_and_store calls Base.metadata.create_all(...) at import time.
+    # Patch it to keep tests independent from a running Postgres instance.
+    monkeypatch.setattr(MetaData, "create_all", lambda _self, bind=None: None)
+    sys.modules.pop("fetch_and_store", None)
+    return importlib.import_module("fetch_and_store")
+
+
+def test_process_source_returns_only_new_hackathons(monkeypatch):
+    fetch_and_store = load_fetch_and_store(monkeypatch)
+    sessions = []
+    upsert_results = [(object(), True), (object(), False), (object(), True)]
+    hacks = [SimpleNamespace(id="1"), SimpleNamespace(id="2"), SimpleNamespace(id="3")]
+
+    def fake_session_local():
+        session = SimpleNamespace(rollback=lambda: None, close=lambda: None)
+        sessions.append(session)
+        return session
+
+    def fake_upsert(_db, _hack):
+        return upsert_results.pop(0)
+
+    monkeypatch.setattr(fetch_and_store, "SessionLocal", fake_session_local)
+    monkeypatch.setattr(fetch_and_store, "upsert_hackathon", fake_upsert)
+
+    result = fetch_and_store.process_source("TestSource", lambda: hacks)
+
+    assert [h.id for h in result] == ["1", "3"]
+    assert len(sessions) == 1
+
+
+def test_process_source_retries_on_database_error(monkeypatch):
+    fetch_and_store = load_fetch_and_store(monkeypatch)
+    attempts = {"count": 0}
+    sessions = []
+    sleeps = []
+    hack = SimpleNamespace(id="10")
+
+    def fake_session_local():
+        session = SimpleNamespace(rollback=lambda: None, close=lambda: None)
+        sessions.append(session)
+        return session
+
+    def flaky_fetch():
+        attempts["count"] += 1
+        if attempts["count"] == 1:
+            raise SQLAlchemyError("temporary db error")
+        return [hack]
+
+    monkeypatch.setattr(fetch_and_store, "SessionLocal", fake_session_local)
+    monkeypatch.setattr(fetch_and_store, "upsert_hackathon", lambda _db, _h: (object(), True))
+    monkeypatch.setattr(fetch_and_store.time, "sleep", lambda seconds: sleeps.append(seconds))
+
+    result = fetch_and_store.process_source("TestSource", flaky_fetch)
+
+    assert [h.id for h in result] == ["10"]
+    assert attempts["count"] == 2
+    assert sleeps == [1]
+    assert len(sessions) == 2
+
+
+def test_process_source_does_not_retry_on_non_database_error(monkeypatch):
+    fetch_and_store = load_fetch_and_store(monkeypatch)
+    attempts = {"count": 0}
+
+    def fake_fetch():
+        attempts["count"] += 1
+        raise RuntimeError("non-db failure")
+
+    monkeypatch.setattr(
+        fetch_and_store,
+        "SessionLocal",
+        lambda: SimpleNamespace(rollback=lambda: None, close=lambda: None),
+    )
+
+    result = fetch_and_store.process_source("TestSource", fake_fetch)
+
+    assert result == []
+    assert attempts["count"] == 1

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -1,0 +1,40 @@
+from datetime import date
+
+import pytest
+
+pytest.importorskip("pydantic")
+from backend.schemas import Hackathon
+
+
+def test_hackathon_splits_and_normalizes_tags_from_string():
+    hack = Hackathon(
+        id="abc-1",
+        title="AI Sprint",
+        start_date=date(2026, 2, 10),
+        end_date=date(2026, 2, 12),
+        location="Remote",
+        url="https://example.com",
+        mode="Online",
+        status="Open",
+        source="Devpost",
+        tags="AI, Web3 ,  Cloud  ",
+    )
+
+    assert hack.tags == ["ai", "web3", "cloud"]
+
+
+def test_hackathon_keeps_tags_list_as_is():
+    hack = Hackathon(
+        id="abc-2",
+        title="Build Night",
+        start_date=date(2026, 3, 1),
+        end_date=date(2026, 3, 3),
+        location="SF",
+        url="https://example.com/h2",
+        mode="Hybrid",
+        status="Open",
+        source="MLH",
+        tags=["ml", "iot"],
+    )
+
+    assert hack.tags == ["ml", "iot"]

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -1,0 +1,2 @@
+def test_pytest_collection_smoke():
+    assert True

--- a/tests/test_telegram_channel_bot.py
+++ b/tests/test_telegram_channel_bot.py
@@ -1,0 +1,108 @@
+import asyncio
+import importlib.util
+import sys
+from datetime import date
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+pytest.importorskip("sqlalchemy")
+from sqlalchemy.sql.schema import MetaData
+
+pytest.importorskip("telegram")
+
+
+def load_channel_bot_module():
+    # telegram-channel-bot imports fetch_and_store, which runs create_all at import time.
+    # Patch it so tests do not require a live database server.
+    sys.modules.pop("fetch_and_store", None)
+    monkeypatched_create_all = lambda _self, bind=None: None
+    original_create_all = MetaData.create_all
+    MetaData.create_all = monkeypatched_create_all
+
+    module_path = Path(__file__).resolve().parents[1] / "telegram-channel-bot.py"
+    spec = importlib.util.spec_from_file_location("telegram_channel_bot", module_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    try:
+        spec.loader.exec_module(module)
+        return module
+    finally:
+        MetaData.create_all = original_create_all
+
+
+def make_hackathon(
+    banner_url="https://example.com/banner.png",
+    prize_pool="$5,000",
+    team_size="1-4",
+    eligibility="Students",
+):
+    return SimpleNamespace(
+        title="Global Hack 2026",
+        start_date=date(2026, 4, 10),
+        end_date=date(2026, 4, 12),
+        location="Remote",
+        mode="Online",
+        status="Open",
+        source="Devpost",
+        prize_pool=prize_pool,
+        team_size=team_size,
+        eligibility=eligibility,
+        banner_url=banner_url,
+        url="https://example.com/hack",
+    )
+
+
+def test_format_hackathon_message_contains_expected_fields(monkeypatch):
+    module = load_channel_bot_module()
+    monkeypatch.setattr("random.choice", lambda emojis: emojis[0])
+    hack = make_hackathon()
+
+    text, photo_url, hackathon_url = module.format_hackathon_message(hack)
+
+    assert text.startswith("🎉 <b>Global Hack 2026</b>")
+    assert "<b>Duration:</b> April 10 - April 12, 2026" in text
+    assert "<b>Prizes:</b>" in text
+    assert "<b>Team Size:</b> 1-4" in text
+    assert "<b>Eligibility:</b> Students" in text
+    assert photo_url == "https://example.com/banner.png"
+    assert hackathon_url == "https://example.com/hack"
+
+
+def test_format_hackathon_message_omits_optional_sections(monkeypatch):
+    module = load_channel_bot_module()
+    monkeypatch.setattr("random.choice", lambda emojis: emojis[0])
+    hack = make_hackathon(banner_url=None, prize_pool=None, team_size=None, eligibility=None)
+
+    text, photo_url, _ = module.format_hackathon_message(hack)
+
+    assert "<b>Prizes:</b>" not in text
+    assert "<b>Team Size:</b>" not in text
+    assert "<b>Eligibility:</b>" not in text
+    assert photo_url is None
+
+
+def test_send_to_channel_uses_photo_when_available(monkeypatch):
+    module = load_channel_bot_module()
+    bot = AsyncMock()
+    hack = make_hackathon()
+
+    monkeypatch.setattr(module.asyncio, "sleep", AsyncMock())
+    asyncio.run(module.send_to_channel(bot, "@hackradar", [hack]))
+
+    bot.send_photo.assert_awaited_once()
+    bot.send_message.assert_not_awaited()
+    call_kwargs = bot.send_photo.await_args.kwargs
+    assert call_kwargs["chat_id"] == "@hackradar"
+    assert call_kwargs["photo"] == "https://example.com/banner.png"
+
+
+def test_send_to_channel_returns_early_for_empty_list():
+    module = load_channel_bot_module()
+    bot = AsyncMock()
+
+    asyncio.run(module.send_to_channel(bot, "@hackradar", []))
+
+    bot.send_photo.assert_not_awaited()
+    bot.send_message.assert_not_awaited()


### PR DESCRIPTION
Adds a `pytest` baseline and CI test gating for `main`.

### Included
- Added `pytest` dev dependency and test bootstrap (`tests/conftest.py`).
- Added unit tests for:
  - schema tag parsing (`tests/test_schemas.py`)
  - fetch/retry logic (`tests/test_fetch_and_store.py`)
  - channel message formatting + send behavior (`tests/test_telegram_channel_bot.py`)
  - smoke check (`tests/test_smoke.py`)
- Updated `.github/workflows/docker.yml`:
  - new `test` job (`uv sync --dev` + `uv run pytest -q`)
  - `build` now depends on `test`
  - deploy runs only after a successful build
  - deploy to EC2

### Outcome
Docker build/push and EC2 deploy now happen only if tests pass.